### PR TITLE
Fix version conflicts caused by PR#48

### DIFF
--- a/lib/Connery.Lib.csproj
+++ b/lib/Connery.Lib.csproj
@@ -4,9 +4,9 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.ML" Version="1.5.1" />
-    <PackageReference Include="Microsoft.ML.ImageAnalytics" Version="1.5.1" />
-    <PackageReference Include="Microsoft.ML.Vision" Version="1.5.1" />
+    <PackageReference Include="Microsoft.ML" Version="1.6.0" />
+    <PackageReference Include="Microsoft.ML.ImageAnalytics" Version="1.6.0" />
+    <PackageReference Include="Microsoft.ML.Vision" Version="1.6.0" />
 	<PackageReference Include="SciSharp.TensorFlow.Redist" Version="2.3.0" />
   </ItemGroup>
   

--- a/training/Connery.Training.csproj
+++ b/training/Connery.Training.csproj
@@ -5,9 +5,9 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.ML" Version="1.5.1" />
-    <PackageReference Include="Microsoft.ML.ImageAnalytics" Version="1.5.1" />
-    <PackageReference Include="Microsoft.ML.Vision" Version="1.5.1" />
+    <PackageReference Include="Microsoft.ML" Version="1.6.0" />
+    <PackageReference Include="Microsoft.ML.ImageAnalytics" Version="1.6.0" />
+    <PackageReference Include="Microsoft.ML.Vision" Version="1.6.0" />
 	<PackageReference Include="SciSharp.TensorFlow.Redist" Version="2.3.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump Microsoft.ML.ImageAnalytics from 1.5.1 to 1.6.0. [(PR#48)](https://github.com/maacpiash/Connery/pull/48/).
Hope this fix can help you.

Best regards,
sucrose